### PR TITLE
feat(abort): make abort reason customizable

### DIFF
--- a/src/request-factory.js
+++ b/src/request-factory.js
@@ -6,9 +6,10 @@
  */
 
 angular.module('angular-abortable-requests', ['ngResource'])
+  .constant('DEFAULT_REASON', 'ABORT')
   .factory('RequestFactory', [ '$resource', '$http',
-    'Util', '$q' ,function($resource, $http,
-    Util, $q) {
+    'Util', '$q', 'DEFAULT_REASON', function($resource, $http,
+    Util, $q, DEFAULT_REASON) {
 
     function abortablePromiseWrap (promise, deferred, outstanding) {
 
@@ -52,8 +53,8 @@ angular.module('angular-abortable-requests', ['ngResource'])
           return {
             promise: deferred.promise,
 
-            abort: function (){
-              deferred.reject('ABORT');
+            abort: function (reason) {
+              deferred.reject(getRejectReason(reason));
             }
 
           };
@@ -64,14 +65,22 @@ angular.module('angular-abortable-requests', ['ngResource'])
       * Abort all the outstanding requests on
       * this $resource
       */
-      resource.abortAll = function () {
+      resource.abortAll = function (reason) {
         angular.forEach(outstanding, function(deferred) {
-          deferred.reject('ABORT');
+          deferred.reject(getRejectReason(reason));
         });
         outstanding = [];
       };
 
       return resource;
+    }
+
+    function getRejectReason (reason) {
+      if (!angular.isDefined(reason)) {
+        return DEFAULT_REASON;
+      }
+
+      return reason;
     }
 
     function getHttpConfig (url) {
@@ -93,9 +102,9 @@ angular.module('angular-abortable-requests', ['ngResource'])
         /*
         * Abort all outstanding requests
         */
-        abortAll: function()  {
+        abortAll: function(reason) {
           angular.forEach(outstanding, function(deferred) {
-            deferred.reject('ABORT');
+            deferred.reject(getRejectReason(reason));
           });
           outstanding = [];
         },
@@ -130,8 +139,8 @@ angular.module('angular-abortable-requests', ['ngResource'])
 
             promise: deferred.promise,
 
-            abort: function() {
-              deferred.reject('ABORT');
+            abort: function(reason) {
+              deferred.reject(getRejectReason(reason));
             }
           };
         }

--- a/test/request-factory.js
+++ b/test/request-factory.js
@@ -3,21 +3,30 @@
 describe('RequestFactory', function () {
   var RequestFactory,
     resourceConfig,
+    DEFAULT_REASON,
     $httpBackend;
 
   beforeEach(module('angular-abortable-requests'));
 
   //Takes the api from http/resource
-  function abortRequestTest (api, output) {
-     // abort the request
-    api.abort();
+  function abortRequestTest (api, output, reason) {
+    var expectedReason;
+
+    if (!angular.isDefined(reason)) {
+      expectedReason = DEFAULT_REASON;
+      api.abort();
+    } else {
+      expectedReason = reason;
+      api.abort(reason);
+    }
+
     // on reject
     api.promise.catch(function(err){
       output = err;
     });
 
     $httpBackend.flush();
-    expect(output).toEqual('ABORT');
+    expect(output).toEqual(expectedReason);
   }
 
   function resolveRequestTest (api, output) {
@@ -33,6 +42,7 @@ describe('RequestFactory', function () {
   beforeEach(inject(function ($injector) {
     RequestFactory = $injector.get('RequestFactory');
     $httpBackend = $injector.get('$httpBackend');
+    DEFAULT_REASON = $injector.get('DEFAULT_REASON');
     resourceConfig =  {
       url : '/proxy/test',
       options: null,
@@ -80,6 +90,12 @@ describe('RequestFactory', function () {
           var res, output;
           res = rInstance.get();
           abortRequestTest(res, output);
+        });
+
+        it('returns a promise which can be aborted with a custom reason', function() {
+          var res, output;
+          res = rInstance.get();
+          abortRequestTest(res, output, 'arbitrary reason');
         });
 
         it('returns a promise which resolves',


### PR DESCRIPTION
This change is backwards compatible. The use case is to make it easier for devs to have different logic depending on the reason a request was aborted.