### PR TITLE
Fix removeFromArray

### DIFF
--- a/src/util.js
+++ b/src/util.js
@@ -53,7 +53,10 @@ angular.module('angular-abortable-requests')
      */
     removeFromArray: function(arr, items) {
       var removedItems = [];
-      array.getArray(items).forEach(function(item) {
+      if (!angular.isArray(items)) {
+        items = [items];
+      }
+      angular.forEach(items, function(item) {
         var index = arr.indexOf(item);
         if (index !== -1) {
           arr.splice(index, 1);


### PR DESCRIPTION
Fixes a bug where items were never removed from the array as the variable 'array' was never defined and calling getArray would fail.

This meant that outstanding in request-factory was never cleaned up.
